### PR TITLE
Use a CDN by default

### DIFF
--- a/ckawesome/plugin.js
+++ b/ckawesome/plugin.js
@@ -17,7 +17,7 @@ CKEDITOR.plugins.add('ckawesome', {
     
     init: function(editor) {
     	var config = editor.config;
-    	editor.fontawesomePath = config.fontawesomePath ? config.fontawesomePath : CKEDITOR.plugins.getPath('ckawesome') + 'fontawesome/css/font-awesome.min.css';
+    	editor.fontawesomePath = config.fontawesomePath ? config.fontawesomePath : '//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css';
 
     	CKEDITOR.document.appendStyleSheet(editor.fontawesomePath);
     	editor.addContentsCss(editor.fontawesomePath);


### PR DESCRIPTION
After installation, this should "just work" without having to set a path in config.js. Unfortunately CDNJS doesnt support `/latest/` in url yet, but this is a start. Pulls a relative url for fontawesome.min.css. Thx.