### PR TITLE
Added &nbsp; inside span to allow removal from within wysiwyg

### DIFF
--- a/ckawesome/dialogs/ckawesome.js
+++ b/ckawesome/dialogs/ckawesome.js
@@ -134,6 +134,7 @@ CKEDITOR.dialog.add('ckawesomeDialog', function( editor ) {
             var dialog = this;
 
             var cka = editor.document.createElement( 'span' );
+
             var cka_size = dialog.getValueOf( 'options', 'textsize' );
             var cka_color = dialog.getValueOf( 'options', 'fontcolor' );
             var cka_class = "fa fa-fw " + dialog.getValueOf( 'options', 'ckawesomebox' );
@@ -141,7 +142,9 @@ CKEDITOR.dialog.add('ckawesomeDialog', function( editor ) {
             
             cka.setAttribute( 'class', cka_class );
             if ( cka_style ) cka.setAttribute( 'style', cka_style );
-            
+
+            cka.appendHtml("&nbsp;");
+
             editor.insertElement( cka );
         }
     };


### PR DESCRIPTION
This fixes problem with not being able to remove icon from wysiwyg editor once it's been added to the content. It's been caused by empty span tag, which this fix fills in with <strong>&amp;nbsp;</strong>